### PR TITLE
distill further discussion from list

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -38,7 +38,6 @@ None of these problems are insurmountable. For example PNaCl defines a small por
 * Stable international standards since 2000.
 * Stable .NET and open-source Mono implementations.
 * Mature tools and language support, large user base, open source (even from Microsoft).   
- 
 
 ### Bad   
 * Missing standard SIMD support. (Both Mono and .NET are putting it in, so it should be standard eventually. )
@@ -48,5 +47,25 @@ None of these problems are insurmountable. For example PNaCl defines a small por
 * Did I mention Microsoft?
 
 # RISCV
+### Isn't RISCV a purely hardware spec?
 
-?
+# JVM
+### Nonstarter.  Oracle ownership and intellectual property issues.
+
+# EVM1 -> EVM2
+### Good:
+* We own it.
+* It can evolve to where we need to go.
+* Coordination with other projects is optional.
+* We have the engineering talent we need.
+* We can incorporate wasm and other tech as appropriate.
+
+### Bad:
+* We own it.
+* We will need to maintain and build our own community of developers and users. (This might be a pro.)
+* EVM design has some clunkiness that gets in the way of performance and clean evolution.
+
+chriseth: Is "it is hard to break out of an EVM that was never designed to have external interfaces" a pro?
+
+vbuterin: yep definitely
+


### PR DESCRIPTION
https://gitter.im/ethereum/evm2.0-design, circa early April 2016.  Continuing discussion of EVM2 Design options.  Oracle, Java, and software patents in general.  Upshot is to reject JVM.  Discussion of Python and others not distilled here.  Pros and Cons of evolving what we have.