### PR TITLE
Add eWASM Contract Interface specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A few key points:
 eWASM is a restricted subset of WASM to be used for contracts in Ethereum.
 
 eWASM:
-* specifies the semantics for an *eWASM contract*
+* specifies the [semantics for an *eWASM contract*](./contract_interface.md)
 * specifies an [Ethereum environment interface](./eth_interface.md) to facilitate interaction with the Ethereum environment from an *eWASM contract*
 * specifies [metering](./metering.md) for instructions
 * and aims to restrict [non-deterministic behavior](https://github.com/WebAssembly/design/blob/master/Nondeterminism.md)
@@ -49,6 +49,7 @@ eWASM:
 * [FAQ](./faq.md)
 * [Rationale](./rationale.md)
 * [Ethereum environment interface](./eth_interface.md)
+* [eWASM Contract Interface](./contract_interface.md)
 * [Original Proposal](https://github.com/ethereum/EIPs/issues/48) (EIP#48)
 * [WebAssembly design documents](https://github.com/WebAssembly/design)
 

--- a/contract_interface.md
+++ b/contract_interface.md
@@ -1,0 +1,30 @@
+# eWASM Contract Interface (ECI) Specification; Version 0
+
+The eWASM Contract Interface (ECI) specifies the structure of a contract module.
+
+### Wire format
+
+Every contract must be stored in the [WebAssembly Binary Encoding](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md) format (in short, WASM bytecode).
+
+### Imports
+
+A contract can only import symbols specified in the [Ethereum Environment Interface](./eth_interface.md).
+
+### Exports
+
+A contract must have exactly two exported symbols:
+- `memory`: the shared memory space available for the EEI to write into.
+- `main`: a function with no parameters and no result value.
+
+### Entry point
+
+The method exported as `main` will be executed by the VM.
+
+### Debug-mode
+
+Debug-mode is a special VM option, where an additional set of debugging interfaces are available to contracts.  On a live VM, any bytecode trying to import these
+symbols should be rejected.
+
+The imports are available under the `debug` namespace:
+- `print(i32 offset, i32 length)`: print a string as pointed by `offset`
+- `printHex(i32 offset, i32 length)`: print a hex representation of the memory pointed to by `offset`


### PR DESCRIPTION
Specify what is an eWASM contract.

Probably this could be extended with:
- The backward compatibility preamble (as discussed in #20)
- The deploy preamble if that is still needed (copying the code)
- Reference to the ABI and recommendation for a dispatcher code layout