### PR TITLE
EEI metering

### DIFF
--- a/feeSchedule.md
+++ b/feeSchedule.md
@@ -147,10 +147,47 @@ All fees for opcodes are currently 1 gas. This needs to be updated before finali
 |-----------|------|
 |unreachable|1     |
 
-# Expanding memory
+
+## Expanding memory
 
 Memory can be expanded in pages, where a page corresponds to 65536 bytes of space.
 
 The EVM1 formula for extending memory is `words * 3 + words ^ 2 / 512` where `word` corresponds to 32 bytes.
 
 From this we can calculate that a 65536 byte page should cost 14336 gas.
+
+
+## Calls to the EEI
+
+Calls to the EEI are charged the same price as their equivalent EVM1 opcode.
+
+| Method               | EVM1 Opcode  |
+|----------------------|--------------|
+| getAddress           | ADDRESS      |
+| getBalance           | BALANCE      |
+| getBlockHash         | BLOCKHASH    |
+| call                 | CALL         |
+| callDataCopy         | CALLDATACOPY |
+| getCallDataSize      | CALLDATASIZE |
+| callCode             | CALLCODE     |
+| callDelegate         | DELEGATECALL |
+| storageStore         | SSTORE       |
+| storageLoad          | SLOAD        |
+| getCaller            | CALLER       |
+| getCallValue         | CALLVALUE    |
+| codeCopy             | CODECOPY     |
+| getCodeSize          | CODESIZE     |
+| getBlockCoinbase     | COINBASE     |
+| create               | CREATE       |
+| getBlockDifficulty   | DIFFICULTY   |
+| externalCodeCopy     | EXTCODECOPY  |
+| getExternalCodeSize  | EXTCODESIZE  |
+| getGasLeft           | GAS          |
+| getBlockGasLimit     | GASLIMIT     |
+| getTxGasPrice        | GASPRICE     |
+| log                  | LOG*n*       |
+| getBlockNumber       | NUMBER       |
+| getTxOrigin          | ORIGIN       |
+| return               | RETURN       |
+| selfDestruct         | SELFDESTRUCT |
+| getBlockTimestamp    | TIMESTAMP    |

--- a/metering.md
+++ b/metering.md
@@ -42,9 +42,9 @@ The cost of pre-allocated memory must be included in the very first metering cal
 
 Any calls to `grow_memory` needs to be prepended with a call for metering.
 
-## TODO
+## Special metering: Ethereum environment interface (EEI)
 
-* Specify a cost table for Ethereum System calls
+Calls to the EEI methods do not need to be metered separately, because they will deduct gas on their own.
 
 ## Examples
 

--- a/metering.md
+++ b/metering.md
@@ -44,7 +44,7 @@ Any calls to `grow_memory` needs to be prepended with a call for metering.
 
 ## Special metering: Ethereum environment interface (EEI)
 
-Calls to the EEI methods do not need to be metered separately, because they will deduct gas on their own.
+Other than the cost of `call_import`, calls to the EEI methods do not need to be metered separately, because they will deduct gas on their own.
 
 ## Examples
 


### PR DESCRIPTION
I think the system calls shouldn't be metered from outside, rather they should calculate and deduct the gas.

Rationale:
- some of them have fixed fees
- some are depending data submitted (`LOG`)
- some are depending on the state of outside resources (`SSTORE`)

This puts too much of a burden to metering code and these costs don't really depend on the execution speed of the system (i.e. EVM1 vs. eWASM)

